### PR TITLE
Feat: Adiciona navegação entre as cells da tableView e o DetailsViewController

### DIFF
--- a/solutions/devsprint-rafael-silva-2/GitHubApp/Screens/List/ListView.swift
+++ b/solutions/devsprint-rafael-silva-2/GitHubApp/Screens/List/ListView.swift
@@ -5,6 +5,10 @@
 //  Created by Rodrigo Borges on 30/09/21.
 //
 
+protocol CellDelegate: AnyObject {
+    func didClick()
+}
+
 import UIKit
 
 struct ListViewConfiguration {
@@ -13,6 +17,8 @@ struct ListViewConfiguration {
 }
 
 final class ListView: UIView {
+    
+    weak var delegate: CellDelegate?
 
     private let listViewCellIdentifier = "ListViewCellIdentifier"
 
@@ -24,6 +30,8 @@ final class ListView: UIView {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: self.listViewCellIdentifier)
         tableView.dataSource = self
+        tableView.delegate = self
+        
         return tableView
     }()
 
@@ -90,3 +98,8 @@ extension ListView: UITableViewDataSource {
     }
 }
 
+extension ListView: UITableViewDelegate {
+    public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        delegate?.didClick()
+    }
+}

--- a/solutions/devsprint-rafael-silva-2/GitHubApp/Screens/List/ListViewController.swift
+++ b/solutions/devsprint-rafael-silva-2/GitHubApp/Screens/List/ListViewController.swift
@@ -43,6 +43,7 @@ final class ListViewController: UIViewController {
     
     init() {
         super.init(nibName: nil, bundle: nil)
+        listView.delegate = self
         
     }
     
@@ -80,5 +81,11 @@ extension ListViewController: UISearchResultsUpdating{
             return
         }
         
+    }
+}
+
+extension ListViewController: CellDelegate {
+    func didClick() {
+        navigationController?.pushViewController(DetailViewController(), animated: true)
     }
 }


### PR DESCRIPTION
 ### Descrição da task

Ao selecionar um repositório da lista, deve-se navegar para a tela de Detalhes (DetailViewController).
 
 
### Critérios de aceite
- [X] Ao tocar em um item da lista de repositórios, o app deve navegar para a DetailsViewController
